### PR TITLE
Optional deep merge on updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### 3.1.0
+
+- Added option to start with a `baseRef` such as `"users/:uid"`
+
 ##### 3.0.0 - 23 August 2017
 
 Stable 3.0.0 release

--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,7 @@ export function FirebaseAdapter (opts) {
    */
   if (opts.db) {
     this.db = opts.db || firebase.database()
+    this.baseRef = opts.baseRef ? this.db.ref(opts.baseRef) : this.db.ref();
   }
 }
 
@@ -482,7 +483,7 @@ utils.addHiddenPropsToTarget(FirebaseAdapter.prototype, {
 
   getRef (mapper, opts) {
     opts = opts || {}
-    return this.db.ref().child(opts.endpoint || mapper.endpoint || mapper.name)
+    return this.baseRef.child(opts.endpoint || mapper.endpoint || mapper.name)
   },
 
   create (mapper, props, opts) {

--- a/src/index.js
+++ b/src/index.js
@@ -423,6 +423,7 @@ utils.addHiddenPropsToTarget(FirebaseAdapter.prototype, {
    * @param {(string|number)} id The primary key of the record to be updated.
    * @param {Object} props The update to apply to the record.
    * @param {Object} [opts] Configuration options.
+   * @param {boolean} [opts.deepMerge] Disable deep merging with current value by passing `false`
    * @return {Promise}
    */
   _update (mapper, id, props, opts) {

--- a/src/index.js
+++ b/src/index.js
@@ -435,8 +435,8 @@ utils.addHiddenPropsToTarget(FirebaseAdapter.prototype, {
         if (!currentVal) {
           throw new Error('Not Found')
         }
-        utils.deepMixIn(currentVal, props)
-        return itemRef.set(currentVal)
+        const newVal = opts.deepMerge !== false ? utils.deepMixIn(currentVal, props) : props
+        return itemRef.set(newVal)
       })
       .then(() => this._once(itemRef))
       .then((record) => {


### PR DESCRIPTION
Howdy!

A deep merge [forcefully happens](https://github.com/js-data/js-data-firebase/blob/master/src/index.js#L438) when updating items in Firebase. This PR will add the option to disable it by passing in an option `deepMerge` set to `false`. Since the default behavior was deep merge for so long I wouldn't want to change the default for anyone who relies on it, thus a new option was born.

Example usage:
```js
// from a record instance
entry.save({ deepMerge: false })

// note: save calls create or update automatically
```

- [x] - `npm test` succeeds
- [ ] - Code coverage does not decrease (if any source code was changed)
- [ ] - Appropriate JSDoc comments were updated in source code (if applicable)
- [ ] - Appropriate changes to js-data.io docs have been suggested ("Suggest Edits" button)


